### PR TITLE
Filter out 'resolved' field from shrink-wrap files.

### DIFF
--- a/gulp-npmworkspace/src/Plugins/PublishPackages.ts
+++ b/gulp-npmworkspace/src/Plugins/PublishPackages.ts
@@ -5,6 +5,7 @@ import * as _ from "underscore";
 import * as jsonFile from "jsonfile";
 import File = require("vinyl");
 import * as path from "path";
+import fs = require("fs");
 
 import {ConditionableAction, AsyncAction, executeAsynchronousActions} from "./ConditionableAction";
 import {NpmPluginBinding} from "./utilities/NpmPluginBinding";
@@ -98,6 +99,18 @@ function npmPublishPackage(packageDescriptor: PackageDescriptor, packagePath: st
         let publishFunc = () => {
             if (pluginBinding.options.shrinkWrap) {
                 pluginBinding.shellExecuteNpm(packagePath, [ "shrinkwrap" ]);
+                // filter out the 'resolved' fields.
+                var shrinkwrap = require(packagePath+'/npm-shrinkwrap.json');
+
+                function replacer(key, val) {
+                    if (key === 'resolved' && this.from && this.version) {
+                        return undefined;
+                    } else {
+                        return val;
+                    }
+                }
+
+                fs.writeFileSync(packagePath+'/npm-shrinkwrap.json', JSON.stringify(shrinkwrap, replacer, 2));
             }
 
             let versionBump = pluginBinding.options.versionBump;


### PR DESCRIPTION
The `resolved` field is _meant_ to ensure packages are installed from the correct registry, but when building on shared equipment (i.e. build servers) the resolved field causes a range of problems.

This patch filters out the field so installs will come from the user's selected registry or proxy and not bypass it.

(note the `function` on line 105 should **not** be converted to a Typescript lambda, as it needs the `this` context provided by `JSON.stringify`)
