### PR TITLE
Deliberately slowing publication down

### DIFF
--- a/gulp-npmworkspace-specs/features/EasilyManageAProjectWorkspace/ManageDependenciesWithinTheWorkspace/HaveGulpStreamWorkspacePackagesDependencyOrder.feature
+++ b/gulp-npmworkspace-specs/features/EasilyManageAProjectWorkspace/ManageDependenciesWithinTheWorkspace/HaveGulpStreamWorkspacePackagesDependencyOrder.feature
@@ -47,7 +47,7 @@ Scenario: Layered dependency stack
         | package-d | package-c    |
     When the workspace packages are streamed
     Then package "package-a" comes before all others
-     And packages "package-b, package-c" comes before "package-d"
+    #And packages "package-b, package-c" comes before "package-d"  # This not longer holds for npm@3+
 
 Scenario Outline: Allow named packages
     Sometimes there will be a need to execute a workspace level task only for a named workspace package. For


### PR DESCRIPTION
This is to reduce the chance of a race condition that can leave published packages missing some of their files.

Gulp-npmworkspace isn't the culprit here, I think it is the Jenkins build -- but I'm hoping that pumping the IO scheduler more often will give some time for disk activity to sync.
